### PR TITLE
added async changes to wiki_ner

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
+          pip install pytest-asyncio
           pip install -r requirements.txt
 
       - name: Run tests with pytest

--- a/wiki-NER/test_wiki_ner.py
+++ b/wiki-NER/test_wiki_ner.py
@@ -1,10 +1,10 @@
 # pylint: skip-file
 import pytest
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock, PropertyMock
 import wiki_ner
 
 # --- 1. CONFIGURATION & RESET ---
+
 
 @pytest.fixture(autouse=True)
 def reset_state(monkeypatch):
@@ -14,32 +14,44 @@ def reset_state(monkeypatch):
     monkeypatch.setenv("SECRET_ID", "test-secret")
     monkeypatch.setenv("AWS_REGION", "eu-west-2")
 
-# --- 2. SUCCESS CASE  ---
+# --- 2. HAPPY PATHS ---
 
-@patch("wiki_ner.sm_client.get_secret_value")
-@patch("wiki_ner.OpenAI")
-@patch("wiki_ner.wikipedia.search")
+
+@patch("wiki_ner.extract_wiki_terms_from_claims")
+@patch("wiki_ner.resolve_wiki_titles")
 @patch("wiki_ner.wiki_api.page")
-def test_full_pipeline_success(mock_page, mock_search, mock_oa, mock_sm):
-    # Setup Mocks with Placeholder Data
-    mock_sm.return_value = {'SecretString': json.dumps({'OPENAI_API_KEY': 'sk-test'})}
-    mock_oa.return_value.chat.completions.create.return_value.choices[0].message.content = \
-        json.dumps({"search_terms": ["Eiffel Tower"]})
-    mock_search.return_value = ["Eiffel Tower"]
-    
-    p = MagicMock()
-    p.exists.return_value = True
-    p.summary = "A tower in Paris."
-    p.fullurl = "https://wiki.com/eiffel"
-    p.sections = [MagicMock(title="History", text="Built in 1887")]
-    mock_page.return_value = p
+def test_lambda_handler_success(mock_page_factory, mock_resolve, mock_extract):
+    # 1. Setup basic mocks
+    mock_extract.return_value = ["Mars"]
+    mock_resolve.return_value = ["Mars"]
 
-    response = wiki_ner.lambda_handler({"claims": ["Paris has a tower"]}, None)
-    
+    # 2. Create the page mock
+    mock_page = MagicMock()
+
+    # .exists() is a METHOD call: await page.exists()
+    mock_page.exists = AsyncMock(return_value=True)
+
+    # .sections, .fullurl, and .summary are PROPERTIES being awaited
+    # We use PropertyMock to return an AsyncMock's return value
+    type(mock_page).sections = PropertyMock(
+        return_value=AsyncMock(return_value=[])())
+    type(mock_page).fullurl = PropertyMock(
+        return_value=AsyncMock(return_value="https://url.com")())
+    type(mock_page).summary = PropertyMock(
+        return_value=AsyncMock(return_value="Summary text")())
+
+    mock_page_factory.return_value = mock_page
+
+    # 3. Execute
+    event = {"claims": ["Water on Mars"]}
+    response = wiki_ner.lambda_handler(event, {})
+
+    # 4. Assert
     assert response["statusCode"] == 200
-    assert "Eiffel Tower" in response["body"]
+    assert "Summary text" in response["body"]
 
 # --- 3. EDGE CASES  ---
+
 
 @pytest.mark.parametrize("invalid_event", [{}, {"claims": []}, {"claims": None}])
 def test_handler_rejects_bad_input(invalid_event):
@@ -47,27 +59,38 @@ def test_handler_rejects_bad_input(invalid_event):
     response = wiki_ner.lambda_handler(invalid_event, None)
     assert response["statusCode"] == 400
 
+
 @patch("wiki_ner.get_openai_client")
 def test_llm_garbage_parsing(mock_client):
     """Verifies that the LLM returning non-JSON text doesn't crash the code."""
-    mock_client.return_value.chat.completions.create.return_value.choices[0].message.content = "I am a pirate, not a JSON!"
-    
-    terms = wiki_ner.extract_wiki_terms_from_claims(["Test"])
-    assert terms == [] # Should recover and return empty list
+    mock_client.return_value.chat.completions.create.return_value.choices[
+        0].message.content = "I am a pirate, not a JSON!"
 
+    terms = wiki_ner.extract_wiki_terms_from_claims(["Test"])
+    assert terms == []  # Should recover and return empty list
+
+
+@pytest.mark.asyncio  # If using pytest-asyncio
 @patch("wiki_ner.wiki_api.page")
-def test_wikipedia_page_missing(mock_page):
+async def test_wikipedia_page_missing(mock_page):
     """Verifies that 404s from Wikipedia are handled without errors."""
-    mock_page.return_value.exists.return_value = False
-    
-    result = wiki_ner.fetch_article_body("Atlantis", ["ocean"])
-    assert result == {} # Should return empty dict for non-existent page
+
+    # Configure the mock to return an object where .exists() is an AsyncMock
+    mock_exists = AsyncMock(return_value=False)
+    mock_page.return_value.exists = mock_exists
+
+    # Await the function call
+    result = await wiki_ner.fetch_article_body("Atlantis", ["ocean"])
+
+    assert result == {}
+    mock_exists.assert_awaited_once()
+
 
 @patch("wiki_ner.sm_client.get_secret_value")
 def test_aws_infrastructure_failure(mock_sm):
     """Verifies the 500 error catch-all when AWS is unreachable."""
     mock_sm.side_effect = Exception("Connection Timeout")
-    
+
     response = wiki_ner.lambda_handler({"claims": ["Test"]}, None)
     assert response["statusCode"] == 500
     assert "Internal research engine error" in response["body"]

--- a/wiki-NER/wiki_ner.py
+++ b/wiki-NER/wiki_ner.py
@@ -181,7 +181,7 @@ async def fetch_article_bodies(titles: list[str], claims: list[str]) -> list[dic
     return await asyncio.gather(*tasks)
 
 
-def lambda_handler(event, context):
+def lambda_handler(event: dict, context: dict) -> dict:
     """ Coordinates the flow from Claim Input -> Search Terms -> Wiki Data Retrieval. """
 
     logging.info(f"Lambda execution started", extra={"event": event})


### PR DESCRIPTION
# Description

Added asynchronous processing to wiki_ner for getting the Wikipedia articles for the claim terms. This makes it significantly faster. During testing, I found that, for about 5 titles, it would get all of the sections for the wiki titles in about 10% of the time. Right now, it seems like the connection to the LLM for claim extraction is the biggest bottleneck.

### Type of change

optimisation