### PR TITLE
added workflow for pushing images to AWS ECR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write # Required for requesting the JWT
+  contents: read  # Required for actions/checkout
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - { name: "wiki-ner", path: "./wiki-NER", ecr_repo: "c22-dv-wiki-ner-repo" }
+          - { name: "url-scraper", path: "./url_scraper", ecr_repo: "c22-dv-url-scraper-repo" }
+          - { name: "rag", path: "./rss_pipeline/rag", ecr_repo: "c22-dv-rag-image" }
+          - { name: "rss-pipeline", path: "./rss_pipeline", ecr_repo: "c22-dv-pipeline-image" }
+          - { name: "streamlit", path: "./streamlit", ecr_repo: "c22-dv-streamlit-image" }
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ecr-role
+          aws-region: eu-west-2 # Change to your region
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, Tag, and Push Image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ matrix.service.ecr_repo }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # 1. Ensure repo exists (from your script)
+          aws ecr describe-repositories --repository-names $ECR_REPOSITORY || \
+          aws ecr create-repository --repository-name $ECR_REPOSITORY
+
+          # 2. Build with explicit platform (important for Lambda/ECS)
+          docker build \
+            --platform linux/amd64 \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            ${{ matrix.service.path }}
+
+          # 3. Push both tags
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+
+          

--- a/terraform/github_permissions.tf
+++ b/terraform/github_permissions.tf
@@ -1,0 +1,110 @@
+# --- 1. GitHub OIDC Identity Provider ---
+# This allows GitHub to talk to AWS without passwords/keys
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["1c5815a4a15c156637373f73c683777d85c4909a"] 
+}
+
+# --- 2. IAM Role for GitHub Actions ---
+resource "aws_iam_role" "github_actions_ecr" {
+  name = "github-actions-ecr-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Condition = {
+          StringLike = {
+            # CRITICAL: Restrict this to ONLY your specific repository
+            "token.actions.githubusercontent.com:sub" = "repo:ConnorCalkin/DisinformationVerifier:*"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# --- 3. Permissions Policy ---
+# Added 'ecr:CreateRepository' and 'ecr:DescribeRepositories' 
+# so the GitHub workflow can auto-create missing repos.
+resource "aws_iam_role_policy" "ecr_policy" {
+  name = "github-actions-ecr-policy"
+  role = aws_iam_role.github_actions_ecr.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeRepositories",
+          "ecr:CreateRepository"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# --- 4. ECR Repositories ---
+locals {
+  repo_names = [
+    "c22-dv-wiki-ner-repo",
+    "c22-dv-url-scraper-repo",
+    "c22-dv-rag-image",
+    "c22-dv-pipeline-image",
+    "c22-dv-streamlit-image"
+  ]
+}
+
+resource "aws_ecr_repository" "repos" {
+  for_each             = toset(local.repo_names)
+  name                 = each.value
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# --- 5. Lifecycle Policy (Cost Savings) ---
+# Automatically deletes old images, keeping only the 10 most recent.
+resource "aws_ecr_lifecycle_policy" "cleanup" {
+  for_each   = toset(local.repo_names)
+  repository = aws_ecr_repository.repos[each.value].name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 10 images to save costs"
+      selection = {
+        tagStatus     = "any"
+        countType     = "imageCountMoreThan"
+        countNumber   = 10
+      }
+      action = {
+        type = "expire"
+      }
+    }]
+  })
+}
+
+# --- Outputs ---
+output "role_arn" {
+  value       = aws_iam_role.github_actions_ecr.arn
+  description = "Copy this ARN into your GitHub Action 'role-to-assume' field."
+}


### PR DESCRIPTION
# Description

As part of creating a CI/CD workflow, this would add a new workflow that should automatically push all of our images to AWS when we push to main.

- workflow script for actually running the script to push an image
- Terraform to give the workflow the necessary permissions to be able to act out the workflow

This is currently untested because I don't know how to test workflows locally

### Future steps

This is a proof of concept to start the deployment pipeline. In theory, this will need to alter the lambdas and the ECR, but that seems like too much complexity to add all at once